### PR TITLE
initialize pin.mode when using digital output

### DIFF
--- a/pyfirmata2/pyfirmata2.py
+++ b/pyfirmata2/pyfirmata2.py
@@ -287,6 +287,8 @@ class Board(object):
                 pin.mode = INPUT_PULLUP
             elif bits[2] != 'o':
                 pin.mode = INPUT
+            elif bits[2] == 'o':
+                pin.mode = OUTPUT
         else:
             pin.enable_reporting()
         return pin


### PR DESCRIPTION
when using a pin in digital output mode, the pin object does not return with the correct pin.mode.

I had this working in windows but it was not working on my ubuntu machine, the change proposed by this PR fixes the problem in a very simple manner.

I do not understand why it would work in windows but don,t have much more time to investigate. The proposed modification makes sense in my opinion, please review and advise if you would like me to change to something else.

Regards,
Francois