### PR TITLE
UART

### DIFF
--- a/pyfirmata2/boards.py
+++ b/pyfirmata2/boards.py
@@ -4,27 +4,31 @@ BOARDS = {
         'analog': tuple(x for x in range(6)),
         'pwm': (3, 5, 6, 9, 10, 11),
         'use_ports': True,
-        'disabled': (0, 1)  # Rx, Tx, Crystal
+        'disabled': (0, 1), # Rx, Tx, Crystal
+        'serial' : (0)       # Serial0 unavailable
     },
     'arduino_mega': {
-        'digital': tuple(x for x in range(54)),
+        'digital': tuple(x for x in range(86)),
         'analog': tuple(x for x in range(16)),
         'pwm': tuple(x for x in range(2, 14)),
         'use_ports': True,
-        'disabled': (0, 1)  # Rx, Tx, Crystal
+        'disabled': (0, 1),     # Rx, Tx, Crystal
+        'serial' : (0, 1, 2, 3)    # Serial0 unavailable
     },
     'arduino_due': {
         'digital': tuple(x for x in range(54)),
         'analog': tuple(x for x in range(12)),
         'pwm': tuple(x for x in range(2, 14)),
         'use_ports': True,
-        'disabled': (0, 1)  # Rx, Tx, Crystal
+        'disabled': (0, 1),     # Rx, Tx, Crystal
+        'serial' : (0, 1, 2, 3)    # Serial0 unavailable
     },
     'arduino_nano': {
         'digital': tuple(x for x in range(14)),
         'analog': tuple(x for x in range(8)),
         'pwm': (3, 5, 6, 9, 10, 11),
         'use_ports': True,
-        'disabled': (0, 1)  # Rx, Tx, Crystal
+        'disabled': (0, 1), # Rx, Tx, Crystal
+        'serial' : (0)       # Serial0 unavailable
     }
 }

--- a/pyfirmata2/constants.py
+++ b/pyfirmata2/constants.py
@@ -1,0 +1,103 @@
+
+# Message command bytes (0x80(128) to 0xFF(255)) - straight from Firmata.h
+ANALOG_MESSAGE = 0xE0       # send data for an analog pin (or PWM)
+DIGITAL_MESSAGE = 0x90      # send data for a digital pin
+REPORT_ANALOG = 0xC0        # enable analog input by pin #
+REPORT_DIGITAL = 0xD0       # enable digital input by port pair
+
+START_SYSEX = 0xF0          # start a MIDI SysEx msg
+SET_PIN_MODE = 0xF4         # set a pin to INPUT/OUTPUT/PWM/etc
+SET_PIN_VALUE = 0xF5        # set digital pin value to 0/1
+END_SYSEX = 0xF7            # end a MIDI SysEx msg
+REPORT_VERSION = 0xF9       # report firmware version
+SYSTEM_RESET = 0xFF         # reset from MIDI
+
+# SysEx core features
+EXTENDED_ID =0X00           # next two bytes are used to define the extended ID
+                            # 0x01-0x0F reserved
+ANALOG_MAPPING_QUERY = 0x69     # ask for mapping of analog to pin numbers
+ANALOG_MAPPING_RESPONSE = 0x6A  # reply with mapping info
+CAPABILITY_QUERY = 0x6B         # ask for supported modes and resolution of all pins
+CAPABILITY_RESPONSE = 0x6C      # reply with supported modes and resolution
+PIN_STATE_QUERY = 0x6D          # ask for a pin's current mode and value
+PIN_STATE_RESPONSE = 0x6E       # reply with pin's current mode and value
+EXTENDED_ANALOG = 0x6F          # analog write (PWM, Servo, etc) to any pin
+STRING_DATA = 0x71          # a string message with 14-bits per char
+REPORT_FIRMWARE = 0x79      # report name and version of the firmware
+SAMPLING_INTERVAL = 0x7A    # set the poll rate of the main loop
+SYSEX_NON_REALTIME = 0x7E   # MIDI Reserved for non-realtime messages
+SYSEX_REALTIME = 0x7F       # MIDI Reserved for realtime messages
+
+# SysEx optional features
+SERIAL_DATA = 0X60
+ENCODER_DATA = 0X61
+ACCELSTEPPER_DATA = 0X62
+SPI_DATA = 0X68
+SERVO_CONFIG = 0X70
+ONEWIRE_DATA = 0X73
+DHTSENSOR_DATA = 0x74
+SHIFT_DATA = 0x75           # a bitstream to/from a shift register
+I2C_REQUEST = 0x76          # send an I2C read/write request
+I2C_REPLY = 0x77            # a reply to an I2C read request
+I2C_CONFIG = 0x78           # config I2C settings such as delay times and power pins
+
+# Pin modes.
+# except from UNAVAILABLE taken from Firmata.h
+UNAVAILABLE = -1
+INPUT = 0          # as defined in wiring.h
+OUTPUT = 1         # as defined in wiring.h
+ANALOG = 2         # analog pin in analogInput mode
+PWM = 3            # digital pin in PWM output mode
+SERVO = 4          # digital pin in SERVO mode
+SERIAL = 10        # serial pin (Rx | Tx)
+INPUT_PULLUP = 11  # Same as INPUT, but with the pin's internal pull-up resistor enabled
+
+# Pin types
+DIGITAL = OUTPUT   # same as OUTPUT below
+# ANALOG is already defined above
+
+# Time to wait after initializing serial, used in Board.__init__
+BOARD_SETUP_WAIT_TIME = 2
+
+##################
+#     SERIAL     #
+##################
+
+# See https://github.com/firmata/protocol/blob/master/serial-1.0.md for more info
+# SysEx command byte
+SERIAL_DATA = 0X60
+
+# Command bytes (add port descriptor f.e. Config HW_serial1 -> 0x11)
+SERIAL_CONFIG   = 0x10
+SERIAL_WRITE    = 0x20
+SERIAL_READ     = 0x30
+SERIAL_REPLY    = 0x40
+SERIAL_CLOSE    = 0x50
+SERIAL_FLUSH    = 0x60
+SERIAL_LISTEN   = 0x70
+
+# Serial port descriptor
+HW_SERIAL0 = 0x00
+HW_SERIAL1 = 0x01
+HW_SERIAL2 = 0x02
+HW_SERIAL3 = 0x03
+
+SW_SERIAL0 = 0x08
+SW_SERIAL1 = 0x09
+SW_SERIAL2 = 0x0A
+SW_SERIAL3 = 0x0B
+
+# serial capable pin
+PIN_MODE_SERIAL = 0x0A
+
+# Capability response
+# Where the pin mode = "Serial" and the pin resolution = one of the following:
+RES_RX0 = 0x00
+RES_TX0 = 0x01
+RES_RX1 = 0x02
+RES_TX1 = 0x03
+RES_RX2 = 0x04
+RES_TX2 = 0x05
+RES_RX3 = 0x06
+RES_TX3 = 0x07
+# extensible up to 8 HW ports

--- a/pyfirmata2/pyfirmata2.py
+++ b/pyfirmata2/pyfirmata2.py
@@ -235,7 +235,11 @@ class Board(object):
                 pin.mode = SERVO
             elif bits[2] == 'u':
                 pin.mode = INPUT_PULLUP
-            elif bits[2] != 'o':
+            elif bits[2] == 'i':
+                pin.mode = INPUT
+            elif bits[2] == 'o':
+                pin.mode = OUTPUT
+            else:
                 pin.mode = INPUT
         else:
             pin.enable_reporting()

--- a/pyfirmata2/serial.py
+++ b/pyfirmata2/serial.py
@@ -1,0 +1,81 @@
+from .constants import *
+
+class MissingPinDefinitionError(Exception):
+    pass
+
+class Serial(object):
+    """ Object for serial port handling. """
+    def __init__(self, board, port) -> None:
+        self._board = board
+        self._port = port
+        self._buff = []
+
+    def start(self, baudRate=115200, rx=None, tx=None) -> None:
+        """ Sends config and starts continous read """
+        self.config(baudRate, rx, tx)
+        self.read(True) # start continous reading
+
+    def config(self, baudRate=115200, rx=None, tx=None) -> None:
+        """ Send Config message """
+        self._baudRate = baudRate
+        command = SERIAL_CONFIG + self._port
+        mask = 0b1111111
+        msg = [command]
+        baud = [baudRate & mask, (baudRate >> 7) & mask, (baudRate >> 14) & mask]
+        msg.extend(baud)
+        if rx==None and tx==None:
+            pass    # Nothing more to be done
+        elif rx!=None & tx!=None:
+            msg.append(rx)
+            msg.append(tx)
+        else:   # Just one pin defined
+            raise MissingPinDefinitionError("Both Rx and Tx pins must be specified")
+        msg = bytearray(msg)
+        self._board.send_sysex(SERIAL_DATA, msg)
+
+    def write(self, data:bytearray):
+        """ Send data thru serial port """
+        command = SERIAL_WRITE + self._port
+        mask = 0b1111111
+        msg = [command]
+        for d in data:
+            d_l = d & mask
+            d_h = (d >> 7)
+            msg.append(d_l)
+            msg.append(d_h)
+        msg = bytearray(msg)
+        self._board.send_sysex(SERIAL_DATA, msg)
+
+    def read(self, continous:bool, maxBytesToRead = None):
+        """ Read bytes of data from serial port """
+        command = SERIAL_READ + self._port
+        mask = 0b1111111
+        msg = [command]
+        msg.append(0x00 if continous is True else 0x01)
+        if maxBytesToRead is not None:
+            d_l = maxBytesToRead & mask
+            d_h = (maxBytesToRead >> 7)
+            msg.append(d_l)
+            msg.append(d_h)
+        msg = bytearray(msg)
+        self._board.send_sysex(SERIAL_DATA, msg)
+
+    def close(self) -> None:
+        """ Closes port. Should not be called directly (pins would still be marked as taken) """
+        command = SERIAL_CLOSE + self._port
+        msg = [command]
+        msg = bytearray(msg)
+        self._board.send_sysex(SERIAL_DATA, msg)
+
+    def readByte(self):
+        """ Used to proccess incomming data """
+        return self._buff.pop(0)
+    
+    def readBytes(self, bytesToRead:int) -> bytes:
+        buff = []
+        for i in range(bytesToRead):
+            buff.append(self.readByte())
+        return buff
+    
+    def available(self) -> int:
+        return len(self._buff)

--- a/pyfirmata2/util.py
+++ b/pyfirmata2/util.py
@@ -104,11 +104,11 @@ def from_two_bytes(bytes):
         except TypeError:
             pass
         return msb << 7 | lsb
+    
 
-
-def two_byte_iter_to_str(bytes):
+def two_byte_iter_to_bytes(bytes):
     """
-    Return a string made from a list of two byte chars.
+    Return a bytearray made from a list of two byte chars.
     """
     bytes = list(bytes)
     chars = bytearray()
@@ -119,6 +119,14 @@ def two_byte_iter_to_str(bytes):
         except IndexError:
             msb = 0x00
         chars.append(from_two_bytes([lsb, msb]))
+    return chars
+
+
+def two_byte_iter_to_str(bytes):
+    """
+    Return a string made from a list of two byte chars.
+    """
+    chars = two_byte_iter_to_bytes(bytes)
     return chars.decode()
 
 


### PR DESCRIPTION
# UART support

Hi, Love your work! I currently needed to control MCU remotely, so I used Firmata and pyFirmata2 library for client. It worked pretty nicely but than I found out I need to use UART and control it remotely as well. Your library is pretty well written so I managed to add this feature and I thougt someone could find it usefull as well as I did not find any other Firmata client for python capable of this. I plan to add I2C support as well in near future.

For now I did not add any test or example.

TODO left: Modify get_pin to add type UART and call this function in get_serial to mark pins as taken

Note: I chanded number of pins for Arduino Mega because I use AtMega2560 on a custom board and I used pins that are not connected on Arduino boards. Feel free to change it back.